### PR TITLE
Twitch feature and Discord clean up

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -83,14 +83,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: hack
-          args: --feature-powerset check --bin ccg_bot --tests
+          args: --feature-powerset check --tests --workspace
   msrv:
     runs-on: ubuntu-latest
     # we use a matrix here just because env can't be used in job names
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       matrix:
-        msrv: [1.63.0] # time v0.3.20
+        msrv: [1.65.0] # let else (discord/id.rs)
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "bitflags 2.0.0",
+ "ccg_bot_sys",
  "dashmap",
  "governor",
  "lazy_static",
@@ -153,6 +154,14 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "twitch-irc",
+]
+
+[[package]]
+name = "ccg_bot_sys"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
-#members = ["ccg_bot_bin", "ccg_bot_sys"] #renable as, and when, the ccg_bot_sys crate is needed
-members = ["ccg_bot_bin"]
+members = ["ccg_bot_bin", "ccg_bot_sys"]
 
 [profile.dev]
 opt-level = 3

--- a/ccg_bot_bin/Cargo.toml
+++ b/ccg_bot_bin/Cargo.toml
@@ -10,11 +10,11 @@ version = "0.0.1"
 edition = "2021"
 include = ["LICENSE.md", "README.md"]
 publish = false
-rust-version = "1.63"
+rust-version = "1.65"
 
 [dependencies]
 async-trait = "0.1"
-#ccg_bot_sys = { version = "0.1.0", path = "../ccg_bot_sys"}# reserve for if proc_macros are needed
+ccg_bot_sys = { version = "0.1.0", path = "../ccg_bot_sys"}
 governor = "0.5"
 lazy_static = "1.4"
 nom = "7.0"
@@ -45,7 +45,7 @@ features = ["full"]
 
 [dependencies.twitch-irc]
 version = "5.0"
-features = ["__refreshing-token", "async-tungstenite", "bytes", "metrics-collection", "prometheus", "refreshing-token-rustls-webpki-roots", "reqwest", "serde", "tokio-native-tls", "tokio-stream", "tokio-util", "transport-tcp", "transport-tcp-native-tls", "transport-ws", "transport-ws-rustls-webpki-roots", "with-serde"]
+features = ["__refreshing-token", "async-tungstenite", "bytes", "prometheus", "refreshing-token-rustls-webpki-roots", "reqwest", "serde", "tokio-native-tls", "tokio-stream", "tokio-util", "transport-tcp", "transport-tcp-native-tls", "transport-ws", "transport-ws-rustls-webpki-roots", "with-serde"]
 optional = true
 
 [dev-dependencies]
@@ -54,7 +54,7 @@ dashmap = { version = "5.1.0", features = ["serde"]}
 tokio-test = "*"
 
 [features]
-default = ["discord"]
+default = ["discord", "twitch"]
 discord = ["serenity"]
 full = ["discord", "twitch"]
 twitch = ["twitch-irc"]

--- a/ccg_bot_bin/clippy.toml
+++ b/ccg_bot_bin/clippy.toml
@@ -1,0 +1,1 @@
+allow-dbg-in-tests = true

--- a/ccg_bot_bin/config.toml.example
+++ b/ccg_bot_bin/config.toml.example
@@ -5,3 +5,4 @@ token = "AbcDEFGhJkl0MnO1PQRsTUvx.Abcdef.AbCDefgHiJkLMNOpqrSTU0vWXy1"
 [twitch]
 channels = ["Twitch", "TwitchRivals"]
 token = ""#Scoped OAuth chat token
+bot_name = "" # The name that obtained the `token` above.

--- a/ccg_bot_bin/src/config.rs
+++ b/ccg_bot_bin/src/config.rs
@@ -14,6 +14,8 @@ struct ConfigToml {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct ConfigTomlTwitch {
     channels: Option<Vec<String>>,
+    token: Option<String>,
+    bot_name: Option<String>,
 }
 
 #[cfg(any(feature = "discord", feature = "full"))]
@@ -23,7 +25,7 @@ struct ConfigTomlDiscord {
     token: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Config {
     #[cfg(any(feature = "discord", feature = "full"))]
     pub discord_guildid: String,
@@ -31,6 +33,10 @@ pub struct Config {
     pub discord_token: String,
     #[cfg(any(feature = "twitch", feature = "full"))]
     pub twitch_channels: Vec<String>,
+    #[cfg(any(feature = "twitch", feature = "full"))]
+    pub twitch_token: String,
+    #[cfg(any(feature = "twitch", feature = "full"))]
+    pub twitch_bot_name: String,
 }
 
 impl Config {
@@ -47,7 +53,7 @@ impl Config {
             }
         }
         let config_toml: ConfigToml = toml::from_str(&content).unwrap_or_else(|_| {
-            eprintln!("Failed to create ConfigToml object out of config file.");
+            error!("Failed to create ConfigToml object out of config file.");
             ConfigToml {
                 #[cfg(any(feature = "discord", feature = "full"))]
                 discord: None,
@@ -58,7 +64,7 @@ impl Config {
         #[cfg(any(feature = "discord", feature = "full"))]
         let discord_guildid: String = match config_toml.discord.clone() {
             Some(dgid) => dgid.guildid.unwrap_or_else(|| {
-                eprintln!("Missing field `guildid` in table [discord]");
+                error!("Missing field `guildid` in table [discord]");
                 "discord".to_string()
             }),
             None => {
@@ -69,23 +75,45 @@ impl Config {
         #[cfg(any(feature = "discord", feature = "full"))]
         let discord_token: String = match config_toml.discord {
             Some(dt) => dt.token.unwrap_or_else(|| {
-                eprintln!("Missing field `token` in table [discord]");
+                error!("Missing field `token` in table [discord]");
                 "discord".to_string()
             }),
             None => {
-                eprintln!("Missing table `[discord]`.");
+                error!("Missing table `[discord]`.");
                 "discord".to_string()
             },
         };
         #[cfg(any(feature = "twitch", feature = "full"))]
-        let twitch_channels: Vec<String> = match config_toml.twitch {
-            Some(twitch) => twitch.channels.unwrap_or_else(|| {
-                eprintln!("Missing field `channels` in table [twitch]");
+        let twitch_channels: Vec<String> = match config_toml.twitch.clone() {
+            Some(tc) => tc.channels.unwrap_or_else(|| {
+                error!("Missing field `channels` in table [twitch]");
                 vec!["twitch".to_owned()]
             }),
             None => {
-                eprintln!("Missing table `[twitch]`.");
+                error!("Missing table `[twitch]`.");
                 vec!["twitch".to_owned()]
+            },
+        };
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        let twitch_token: String = match config_toml.twitch.clone() {
+            Some(tt) => tt.token.unwrap_or_else(|| {
+                error!("Missing field `token` in table [twitch]");
+                "twitch".to_string()
+            }),
+            None => {
+                error!("Missing table `[twitch]`.");
+                "twitch".to_string()
+            },
+        };
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        let twitch_bot_name: String = match config_toml.twitch {
+            Some(tbn) => tbn.bot_name.unwrap_or_else(|| {
+                error!("Missing field `bot_name` in table [twitch]");
+                "twitch".to_string()
+            }),
+            None => {
+                error!("Missing table `[twitch]`.");
+                "twitch".to_string()
             },
         };
         Config {
@@ -95,6 +123,10 @@ impl Config {
             discord_token,
             #[cfg(any(feature = "twitch", feature = "full"))]
             twitch_channels,
+            #[cfg(any(feature = "twitch", feature = "full"))]
+            twitch_token,
+            #[cfg(any(feature = "twitch", feature = "full"))]
+            twitch_bot_name,
         }
     }
 }

--- a/ccg_bot_bin/src/discord/commands/id.rs
+++ b/ccg_bot_bin/src/discord/commands/id.rs
@@ -24,50 +24,49 @@ pub fn run(options: &CommandInteraction, cache: Arc<Cache>) -> CreateEmbed {
     let current_user = (*Arc::try_unwrap(cache).unwrap_err()).current_user();
     let option = options.resolved.as_ref().expect("Expected user object");
 
-    if let CommandInteractionResolved::User(user, member) = option {
-        let mut mem: PartialMember;
-        if member.is_some() {
-            mem = member.clone().unwrap();
-            //This is cursed. There has to be a better way.
-            let mut roles = format!(
-                "{:?}",
-                mem.roles
-                    .drain(..)
-                    .map(|r| format!("{}", r.to_role_cached(c).unwrap()))
-                    .collect::<Vec<_>>()
-            );
-            roles.retain(|c| c != '[');
-            roles.retain(|c| c != ']');
-            roles.retain(|c| c != '"');
-            let mut embed = DiscordEmbed::new()
-                .field("id", format!("`{}`", user.id), true)
-                .field("name", format!("`{}`", user.name), true)
-                .field("mention", format!("<@{}>", user.id), true)
-                .field("roles", roles, false)
-                .thumbnail(user.face())
-                .color(Color::new(0x500060_u32))
-                .title(format!("{}'s info (w/ guild roles)", user.name))
-                .build();
-            embed.author(|a| a.name(current_user.name.to_string()).url(current_user.face()));
-            debug!("{:?}", &embed);
-            debug!("{:?}", &mem);
-            embed
-        } else {
-            let mut embed = DiscordEmbed::new()
-                .field("id", format!("`{}`", user.id), true)
-                .field("name", format!("`{}`", user.name), true)
-                .field("mention", format!("<@{}>", user.id), true)
-                .thumbnail(user.face())
-                .color(Color::new(0x500060_u32))
-                .title(format!("{}'s info", user.name))
-                .build();
-            embed.author(|a| a.name(current_user.name.to_string()).url(current_user.face()));
-            debug!("{:?}", &embed);
-            embed
-        }
+    let res: CreateEmbed;
+    let CommandInteractionResolved::User(user, member) = option else { panic!("unexpected type in resolved")};
+    let mut mem: PartialMember;
+    if member.is_some() {
+        mem = member.clone().unwrap();
+        //This is cursed. There has to be a better way.
+        let mut roles = format!(
+            "{:?}",
+            mem.roles
+                .drain(..)
+                .map(|r| format!("{}", r.to_role_cached(c).unwrap()))
+                .collect::<Vec<_>>()
+        );
+        roles.retain(|c| c != '[');
+        roles.retain(|c| c != ']');
+        roles.retain(|c| c != '"');
+        let mut embed = DiscordEmbed::new()
+            .field("id", format!("`{}`", user.id), true)
+            .field("name", format!("`{}`", user.name), true)
+            .field("mention", format!("<@{}>", user.id), true)
+            .field("roles", roles, false)
+            .thumbnail(user.face())
+            .color(Color::new(0x500060_u32))
+            .title(format!("{}'s info (w/ guild roles)", user.name))
+            .build();
+        embed.author(|a| a.name(current_user.name.to_string()).url(current_user.face()));
+        debug!("{:?}", &embed);
+        debug!("{:?}", &mem);
+        res = embed;
     } else {
-        unreachable!();
+        let mut embed = DiscordEmbed::new()
+            .field("id", format!("`{}`", user.id), true)
+            .field("name", format!("`{}`", user.name), true)
+            .field("mention", format!("<@{}>", user.id), true)
+            .thumbnail(user.face())
+            .color(Color::new(0x500060_u32))
+            .title(format!("{}'s info", user.name))
+            .build();
+        embed.author(|a| a.name(current_user.name.to_string()).url(current_user.face()));
+        debug!("{:?}", &embed);
+        res = embed;
     }
+    res
 }
 
 ///Register the command to be used in the guild.

--- a/ccg_bot_bin/src/discord/mod.rs
+++ b/ccg_bot_bin/src/discord/mod.rs
@@ -1,4 +1,4 @@
-//!Discord module go brr!!!
+//!This way be Discord
 
 //crate
 use crate::config::Config;
@@ -95,7 +95,7 @@ impl EventHandler for Handler {
             Some(channel) => channel.name,
             None => return,
         };
-        println!("[{}] {}: {}", channel_name, msg.author.name, msg.content);
+        println!("[Discord / #{}] {}: {}", channel_name, msg.author.name, msg.content);
     }
 }
 
@@ -172,6 +172,10 @@ pub async fn new(config: Config) -> Result<Handler, serenity::Error> {
         discord_token: "".to_string(),
         #[cfg(any(feature = "twitch", feature = "full"))]
         twitch_channels: vec!["".to_string()],
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_token: "".to_string(),
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_bot_name: "".to_string(),
     }));
 
     c

--- a/ccg_bot_bin/src/internals/macros.rs
+++ b/ccg_bot_bin/src/internals/macros.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "discord", feature = "full"))]
 macro_rules! enum_number {
     ($name:ident { $($(#[$attr:meta])? $variant:ident $(,)? )* }) => {
         impl $name {

--- a/ccg_bot_bin/src/tests/discord.rs
+++ b/ccg_bot_bin/src/tests/discord.rs
@@ -37,10 +37,16 @@ fn it_works() {
     use super::super::config::Config;
     use super::super::discord::*;
     let dc: Result<Handler, serenity::Error> = aw!(new(Config {
+        #[cfg(any(feature = "discord", feature = "full"))]
         discord_token: "".to_string(),
+        #[cfg(any(feature = "discord", feature = "full"))]
         discord_guildid: "".to_string(),
         #[cfg(feature = "twitch")]
         twitch_channels: vec!["".to_string()],
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_token: "".to_string(),
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_bot_name: "".to_string(),
     }));
     let disc_bool: bool = dc.is_ok();
     assert!(disc_bool);
@@ -198,7 +204,7 @@ fn id_command() {
         .field("id", format!("`{}`", user.id), true)
         .field("name", format!("`{}`", user.name), true)
         .field("mention", format!("<@{}>", user.id), true)
-        .field("roles", format!("{}", roles), false)
+        .field("roles", roles.to_string(), false)
         .thumbnail(
             cdn!("/avatars/379001295744532481/072bcea1eedb39786002311d5619a398.webp?size=1024")
                 .to_string(),
@@ -207,8 +213,6 @@ fn id_command() {
         .title(format!("{}'s info (w/ guild roles)", user.name))
         .build();
     embed.author(|a| a.name("".to_string()).url(cdn!("/embed/avatars/0.png").to_string()));
-    dbg!(&run.0);
-    dbg!(&embed.0);
     assert_eq!(Value::from(hashmap_to_json_map(run.0)), Value::from(hashmap_to_json_map(embed.0)));
 }
 
@@ -419,4 +423,11 @@ fn ping_comand() {
     embed.author(|a| a.name("".to_string()).url(cdn!("/embed/avatars/0.png").to_string()));
     //result
     assert_eq!(Value::from(hashmap_to_json_map(run.0)), Value::from(hashmap_to_json_map(embed.0)));
+}
+
+#[test]
+fn hanlder_debug() {
+    use super::super::discord::*;
+    use crate::config::Config;
+    let _ = format!("{:?}", Handler(Config::default()));
 }

--- a/ccg_bot_bin/src/tests/mod.rs
+++ b/ccg_bot_bin/src/tests/mod.rs
@@ -12,5 +12,10 @@ macro_rules! aw {
 
 #[cfg(any(feature = "default", feature = "discord", feature = "full"))]
 mod discord;
-#[cfg(feature = "twitch")]
+#[cfg(any(feature = "default", feature = "twitch", feature = "full"))]
 mod twitch;
+
+#[test]
+fn clippy_dbg() {
+    dbg!("test clippy::dbg_macro lint regression");
+}

--- a/ccg_bot_bin/src/tests/twitch.rs
+++ b/ccg_bot_bin/src/tests/twitch.rs
@@ -1,6 +1,19 @@
-#[allow(unused_imports)]
 #[test]
 fn it_works() {
-    use super::super::twitch::*;
-    assert!(true)
+    use super::super::config::Config;
+    use super::super::twitch::{new, Handler};
+    let twitch: Result<Handler, std::env::VarError> = aw!(new(Config {
+        #[cfg(any(feature = "discord", feature = "full"))]
+        discord_token: "".to_string(),
+        #[cfg(any(feature = "discord", feature = "full"))]
+        discord_guildid: "".to_string(),
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_channels: vec!["".to_string()],
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_token: "".to_string(),
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_bot_name: "".to_string(),
+    }));
+    let twitch_bool: bool = twitch.is_ok();
+    assert!(twitch_bool);
 }

--- a/ccg_bot_bin/src/twitch/mod.rs
+++ b/ccg_bot_bin/src/twitch/mod.rs
@@ -1,38 +1,34 @@
+//!This way be Twitch logging
+
+//crate
+use crate::config::Config;
+
 //std
 use std::error;
 use std::fmt;
-use std::fs::File;
-use std::io::prelude::*;
-use std::str::FromStr;
-use std::sync::Arc;
-use std::time::Duration;
 
 //twitch_irc
-use twitch_irc::login::{LoginCredentials, RefreshingLoginCredentials};
-use twitch_irc::message::{PrivmsgMessage, ServerMessage};
-use twitch_irc::{ClientConfig, SecureWSTransport, TwitchIRCClient};
+use twitch_irc::login::StaticLoginCredentials;
+#[cfg(not(test))]
+use twitch_irc::message::{IRCMessage, PrivmsgMessage, ServerMessage};
+use twitch_irc::{ClientConfig, SecureTCPTransport, TwitchIRCClient};
 
-//nom
-use nom::{branch::alt, bytes::complete::tag_no_case, Finish};
-
-//serde
-use serde_json;
-
-//tracing
-use tracing::{debug, error, info, instrument, trace, warn};
-
-//misc
-use governor::{Quota, RateLimiter};
-
-//modules
+//module(s)
+#[doc(hidden)]
 mod tokens;
+
+#[derive(Debug)]
+#[doc(hidden)]
+pub struct Handler(pub Config);
 
 #[non_exhaustive]
 #[derive(Debug)]
+#[doc(hidden)]
 pub enum TwitchErr {
     VarErr(std::env::VarError),
 }
 
+#[doc(hidden)]
 impl fmt::Display for TwitchErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
@@ -41,6 +37,7 @@ impl fmt::Display for TwitchErr {
     }
 }
 
+#[doc(hidden)]
 impl error::Error for TwitchErr {
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
@@ -49,11 +46,104 @@ impl error::Error for TwitchErr {
     }
 }
 
+#[doc(hidden)]
 impl From<std::env::VarError> for TwitchErr {
     fn from(err: std::env::VarError) -> TwitchErr {
         TwitchErr::VarErr(err)
     }
 }
 
-#[tokio::main]
-pub async fn main() {}
+#[doc(hidden)]
+pub(crate) fn parse_message<L: AsRef<str> + std::fmt::Debug, M: AsRef<str> + std::fmt::Debug>(
+    level: L,
+    message: M,
+) {
+    match level.as_ref() {
+        "info" => info!("Received message: {:?}", message),
+        "trace" => trace!("Received message: {:?}", message),
+        _ => panic!(),
+    }
+}
+
+///Creates a new chat listener for channels in your config.toml
+pub async fn new(config: Config) -> Result<Handler, std::env::VarError> {
+    let t = tokens::load_token(config.clone());
+    let conf = ClientConfig::new_simple(t);
+    #[cfg(not(test))]
+    let (mut incoming_messages, client) =
+        TwitchIRCClient::<SecureTCPTransport, StaticLoginCredentials>::new(conf);
+    #[cfg(test)]
+    let (_incoming_messages, _client) =
+        TwitchIRCClient::<SecureTCPTransport, StaticLoginCredentials>::new(conf);
+    #[cfg(not(test))]
+    let join_handle = tokio::spawn(async move {
+        while let Some(message) = incoming_messages.recv().await {
+            match message {
+                //Match each of the non-exhaustive cases explictly so we can error on unknown ones
+                ServerMessage::ClearChat { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::ClearMsg { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::Generic { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::GlobalUserState { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::Join { .. } => {
+                    parse_message("info", format!("{:?}", message));
+                }, //FIXME: parse join messages like we do privmsg's
+                ServerMessage::Notice { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::Part { .. } => {
+                    parse_message("info", format!("{:?}", message));
+                }, //FIXME: parse part messages like we do privmsg's
+                ServerMessage::Ping { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::Pong { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::Privmsg { .. } => println!(
+                    "[twitch / {}] {}: {}",
+                    PrivmsgMessage::try_from(Into::<IRCMessage>::into(message.clone()))
+                        .unwrap()
+                        .channel_login,
+                    PrivmsgMessage::try_from(Into::<IRCMessage>::into(message.clone()))
+                        .unwrap()
+                        .sender
+                        .login,
+                    PrivmsgMessage::try_from(Into::<IRCMessage>::into(message))
+                        .unwrap()
+                        .message_text
+                ),
+                ServerMessage::Reconnect { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::RoomState { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::UserNotice { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::UserState { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                ServerMessage::Whisper { .. } => {
+                    parse_message("trace", format!("{:?}", message));
+                },
+                _ => eprintln!("received unexpected message variant {:?}", message),
+            }
+        }
+    });
+    #[cfg(not(test))]
+    for channel in &config.twitch_channels {
+        client.join(channel.to_owned().to_lowercase()).unwrap();
+    }
+    #[cfg(not(test))]
+    join_handle.await.unwrap();
+    Ok(Handler(config))
+}

--- a/ccg_bot_bin/src/twitch/tokens.rs
+++ b/ccg_bot_bin/src/twitch/tokens.rs
@@ -1,33 +1,9 @@
-use async_trait::async_trait;
-use serde_json;
+use crate::config::Config;
+use twitch_irc::login::StaticLoginCredentials;
 
-use std::fs::File;
-
-use twitch_irc::login::UserAccessToken;
-
-#[derive(Clone, Debug)]
-pub struct JsonTokenStorage {}
-
-#[async_trait]
-impl twitch_irc::login::TokenStorage for JsonTokenStorage {
-    // IO Errors are fine here, that's all we're doing
-    type LoadError = std::io::Error;
-    type UpdateError = std::io::Error;
-
-    async fn load_token(&mut self) -> Result<UserAccessToken, Self::LoadError> {
-        // Load the currently stored token from the storage.
-        let secrets_file = File::open("secrets.json").expect("Unable to read secrets.json");
-        let secrets: UserAccessToken = serde_json::from_reader(secrets_file)?;
-
-        Ok(secrets)
-    }
-
-    async fn update_token(&mut self, token: &UserAccessToken) -> Result<(), Self::UpdateError> {
-        // Called after the token was updated successfully, to save the new token.
-        // After `update_token()` completes, the `load_token()` method should then return
-        // that token for future invocations
-        let secrets_file = File::create("secrets.json").expect("Unable to create secrets.json");
-        serde_json::to_writer_pretty(secrets_file, token)?;
-        Ok(())
-    }
+#[doc(hidden)]
+pub(crate) fn load_token(config: Config) -> StaticLoginCredentials {
+    let login_name = config.twitch_bot_name;
+    let token = config.twitch_token;
+    StaticLoginCredentials::new(login_name, Some(token))
 }

--- a/ccg_bot_sys/Cargo.toml
+++ b/ccg_bot_sys/Cargo.toml
@@ -7,12 +7,14 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-proc-macro2 = "1.0.51"
-quote = "1.0.23"
-syn = "1.0.109"
+quote = "1"
+
+[dependencies.syn]
+version = "1"
+features = ["derive", "full"]
 
 [lib]
+name = "ccg_bot_sys"
+path = "src/lib.rs"
 proc-macro = true

--- a/ccg_bot_sys/src/lib.rs
+++ b/ccg_bot_sys/src/lib.rs
@@ -1,1 +1,22 @@
+use proc_macro::TokenStream;
+use syn::{parse_macro_input, Item};
 
+mod unstable;
+
+#[proc_macro_attribute]
+pub fn unstable(args: TokenStream, item: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(args as syn::AttributeArgs);
+    let attr = unstable::UnstableAttribute::from(args);
+
+    match parse_macro_input!(item as Item) {
+        Item::Type(item_type) => attr.expand(item_type),
+        Item::Enum(item_enum) => attr.expand(item_enum),
+        Item::Struct(item_struct) => attr.expand(item_struct),
+        Item::Fn(item_fn) => attr.expand(item_fn),
+        Item::Mod(item_mod) => attr.expand(item_mod),
+        Item::Trait(item_trait) => attr.expand(item_trait),
+        Item::Const(item_const) => attr.expand(item_const),
+        Item::Static(item_static) => attr.expand(item_static),
+        _ => panic!("unsupported item type"),
+    }
+}

--- a/ccg_bot_sys/src/unstable.rs
+++ b/ccg_bot_sys/src/unstable.rs
@@ -1,0 +1,146 @@
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{parse_quote, Visibility};
+
+#[derive(Debug)]
+pub(crate) struct UnstableAttribute {
+    feature: Option<String>,
+    issue: Option<String>,
+}
+
+impl UnstableAttribute {
+    fn crate_feature_name(&self) -> String {
+        if let Some(name) = self.feature.as_deref() {
+            format!("unstable-{}", name)
+        } else {
+            String::from("unstable")
+        }
+    }
+
+    pub(crate) fn expand(&self, mut item: impl ItemLike + ToTokens + Clone) -> TokenStream {
+        // We only care about public items.
+        if item.is_public() {
+            let feature_name = self.crate_feature_name();
+
+            if let Some(issue) = &self.issue {
+                let doc_addendum = format!(
+                    "\n\
+                    # Availability\n\
+                    \n\
+                    **This API is marked as unstable** and is only available when \
+                    the `{}` crate feature is enabled. This comes with no stability \
+                    guarantees, and could be changed or removed at any time.
+                    The tracking issue is: [#{}](https://github.com/ZoeS17/CCG_Bot/issues/{})
+                    ",
+                    feature_name, &issue, issue
+                );
+                item.push_attr(parse_quote! {
+                    #[doc = #doc_addendum]
+                });
+            } else {
+                let doc_addendum = format!(
+                    "\n\
+                    # Availability\n\
+                    \n\
+                    **This API is marked as unstable** and is only available when \
+                    the `{}` crate feature is enabled. This comes with no stability \
+                    guarantees, and could be changed or removed at any time.\
+                ",
+                    feature_name
+                );
+                item.push_attr(parse_quote! {
+                    #[doc = #doc_addendum]
+                });
+            }
+
+            let mut hidden_item = item.clone();
+            *hidden_item.visibility_mut() = parse_quote! {
+                pub(crate)
+            };
+
+            TokenStream::from(quote! {
+                #[cfg(feature = #feature_name)]
+                #item
+
+                #[cfg(not(feature = #feature_name))]
+                #[allow(dead_code)]
+                #hidden_item
+            })
+        } else {
+            item.into_token_stream().into()
+        }
+    }
+}
+
+impl From<syn::AttributeArgs> for UnstableAttribute {
+    fn from(args: syn::AttributeArgs) -> Self {
+        let mut feature = None;
+        let mut issue = None;
+
+        for arg in args {
+            if let syn::NestedMeta::Meta(syn::Meta::NameValue(name_value)) = arg {
+                if name_value.path.is_ident("feature") {
+                    match name_value.lit {
+                        syn::Lit::Str(s) => feature = Some(s.value()),
+                        _ => panic!(),
+                    }
+                } else if name_value.path.is_ident("issue") {
+                    match name_value.lit {
+                        syn::Lit::Str(s) => issue = Some(s.value()),
+                        _ => panic!(),
+                    }
+                }
+            }
+        }
+        Self { feature, issue }
+    }
+}
+
+pub(crate) trait ItemLike {
+    fn attrs(&self) -> &[syn::Attribute];
+
+    fn push_attr(&mut self, attr: syn::Attribute);
+
+    fn visibility(&self) -> &Visibility;
+
+    fn visibility_mut(&mut self) -> &mut Visibility;
+
+    fn is_public(&self) -> bool {
+        matches!(self.visibility(), Visibility::Public(_))
+    }
+}
+
+macro_rules! impl_has_visibility {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl ItemLike for $ty {
+                fn attrs(&self) -> &[syn::Attribute] {
+                    &self.attrs
+                }
+
+                fn push_attr(&mut self, attr: syn::Attribute) {
+                    self.attrs.push(attr);
+                }
+
+                fn visibility(&self) -> &Visibility {
+                    &self.vis
+                }
+
+                fn visibility_mut(&mut self) -> &mut Visibility {
+                    &mut self.vis
+                }
+            }
+        )*
+    };
+}
+
+impl_has_visibility!(
+    syn::ItemType,
+    syn::ItemEnum,
+    syn::ItemStruct,
+    syn::ItemFn,
+    syn::ItemMod,
+    syn::ItemTrait,
+    syn::ItemConst,
+    syn::ItemStatic,
+);


### PR DESCRIPTION
* Enable the use of a `ccg_bot_sys::unstable` attribute macro.
* Add `clippy::dbg_macro` lint with `allow-dbg-in-test` set to true
* Replace use of `eprintln` macro with `error` macro from `tracing`
* Bump MSRV to 1.65.0 to use `let ... else` in discord [commands/id.rs#L28]
* Add Twitch module( this should begin work on #2 )

[commands/id.rs#L28]: ../blob/main/ccg_bot_bin/src/discord/commands/id.rs#L28