### PR TITLE
Rewrite Twitch token handing to allow use of Refreshing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,34 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -36,18 +60,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -61,7 +85,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.23.4",
  "tungstenite",
  "webpki-roots",
 ]
@@ -73,6 +97,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,9 +119,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bitflags"
@@ -92,9 +131,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.1.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block-buffer"
@@ -107,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -134,8 +173,9 @@ name = "ccg_bot"
 version = "0.0.1"
 dependencies = [
  "async-trait",
- "bitflags 2.1.0",
+ "bitflags 2.3.3",
  "ccg_bot_sys",
+ "chrono",
  "dashmap",
  "futures",
  "governor",
@@ -174,25 +214,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
- "num-integer",
  "num-traits",
  "serde",
  "winapi",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
 ]
 
 [[package]]
@@ -213,9 +243,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -231,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -249,57 +279,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.15",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.15",
-]
-
-[[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -308,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -333,14 +319,14 @@ dependencies = [
 
 [[package]]
 name = "enum_dispatch"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
+checksum = "8f33313078bb8d4d05a2733a94ac4c2d8a0df9a2b84424ebf4f33bfc224a890e"
 dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -351,7 +337,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -375,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -406,9 +392,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
@@ -469,7 +455,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -520,14 +506,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "governor"
@@ -549,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -573,19 +565,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
-name = "hermit-abi"
-version = "0.2.6"
+name = "hashbrown"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "http"
@@ -623,9 +612,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.26"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -647,22 +636,23 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.2"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
 dependencies = [
+ "futures-util",
  "http",
  "hyper",
- "rustls",
+ "rustls 0.21.5",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -674,19 +664,18 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -699,7 +688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -713,32 +702,32 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
 
 [[package]]
 name = "js-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -751,30 +740,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -782,12 +762,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "mach"
@@ -804,7 +781,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -837,23 +814,22 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -907,16 +883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,25 +893,34 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.17.1"
+name = "object"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
@@ -964,7 +939,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -975,9 +950,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
@@ -1012,48 +987,48 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall",
  "smallvec",
- "windows-sys 0.45.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.0.12"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.12"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -1063,9 +1038,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -1075,9 +1050,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -1114,9 +1089,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -1162,15 +1137,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -1180,11 +1146,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
- "regex-syntax",
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1193,7 +1162,18 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1203,12 +1183,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "reqwest"
-version = "0.11.16"
+name = "regex-syntax"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+
+[[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64 0.21.0",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1226,13 +1212,13 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
+ "rustls 0.21.5",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "tower-service",
  "url",
@@ -1260,17 +1246,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.11"
+name = "rustc-demangle"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.37.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1286,27 +1278,49 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.2"
+name = "rustls"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
 dependencies = [
- "base64 0.21.0",
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64 0.21.2",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1314,12 +1328,6 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -1333,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -1346,9 +1354,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1356,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.160"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
@@ -1375,20 +1383,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.160"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
 dependencies = [
  "itoa",
  "ryu",
@@ -1409,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "serenity"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82fd5e7b5858ad96e99d440138f34f5b98e1b959ebcd3a1036203b30e78eb788"
+checksum = "d007dc45584ecc47e791f2a9a7cf17bf98ac386728106f111159c846d624be3f"
 dependencies = [
  "async-trait",
  "async-tungstenite",
@@ -1477,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1510,9 +1518,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1521,44 +1529,36 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
- "redox_syscall 0.3.5",
+ "redox_syscall",
  "rustix",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
-dependencies = [
- "winapi-util",
+ "windows-sys",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1573,9 +1573,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.20"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
  "serde",
@@ -1585,15 +1585,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -1615,11 +1615,12 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -1629,18 +1630,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1659,16 +1660,26 @@ version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
- "rustls",
+ "rustls 0.20.8",
  "tokio",
  "webpki",
 ]
 
 [[package]]
-name = "tokio-stream"
-version = "0.1.12"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.5",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1690,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1732,20 +1743,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1774,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1809,7 +1820,7 @@ dependencies = [
  "httparse",
  "log",
  "rand",
- "rustls",
+ "rustls 0.20.8",
  "sha-1",
  "thiserror",
  "url",
@@ -1870,9 +1881,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
 name = "unicode-normalization"
@@ -1884,12 +1895,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,9 +1902,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1933,11 +1938,10 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -1955,9 +1959,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1965,24 +1969,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1992,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2002,22 +2006,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.84"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-streams"
@@ -2034,9 +2038,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.61"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2078,15 +2082,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,31 +2093,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2131,44 +2102,23 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2178,21 +2128,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2202,21 +2140,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2226,21 +2152,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["ccg_bot_bin", "ccg_bot_sys"]
+resolver = "2"
 
 [profile.dev]
 opt-level = 3

--- a/ccg_bot_bin/Cargo.toml
+++ b/ccg_bot_bin/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.65"
 [dependencies]
 async-trait = "0.1"
 ccg_bot_sys = { version = "0.1.0", path = "../ccg_bot_sys"}
+chrono = { version = "0.4", default-features = false }
 governor = "0.5"
 lazy_static = "1.4"
 nom = "7.0"

--- a/ccg_bot_bin/config.toml.example
+++ b/ccg_bot_bin/config.toml.example
@@ -4,5 +4,6 @@ token = "AbcDEFGhJkl0MnO1PQRsTUvx.Abcdef.AbCDefgHiJkLMNOpqrSTU0vWXy1"
 
 [twitch]
 channels = ["Twitch", "TwitchRivals"]
-token = ""#Scoped OAuth chat token
-bot_name = "" # The name that obtained the `token` above.
+client_id  ""
+client_secret  ""
+bot_name = "" # The name fallback name for the Bot.

--- a/ccg_bot_bin/src/config.rs
+++ b/ccg_bot_bin/src/config.rs
@@ -292,6 +292,7 @@ mod test {
         let _ = format!("{:?}", all_some); // derive(Debug)
     }
 
+    #[cfg(any(feature = "full", all(feature = "twitch", feature = "discord")))]
     #[test]
     fn derives_config_toml() {
         let all_some = ConfigToml {

--- a/ccg_bot_bin/src/config.rs
+++ b/ccg_bot_bin/src/config.rs
@@ -14,7 +14,8 @@ struct ConfigToml {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 struct ConfigTomlTwitch {
     channels: Option<Vec<String>>,
-    token: Option<String>,
+    client_id: Option<String>,
+    client_secret: Option<String>,
     bot_name: Option<String>,
 }
 
@@ -34,7 +35,9 @@ pub struct Config {
     #[cfg(any(feature = "twitch", feature = "full"))]
     pub twitch_channels: Vec<String>,
     #[cfg(any(feature = "twitch", feature = "full"))]
-    pub twitch_token: String,
+    pub twitch_client_id: String,
+    #[cfg(any(feature = "twitch", feature = "full"))]
+    pub twitch_client_secret: String,
     #[cfg(any(feature = "twitch", feature = "full"))]
     pub twitch_bot_name: String,
 }
@@ -49,7 +52,9 @@ impl Default for Config {
             #[cfg(any(feature = "twitch", feature = "full"))]
             twitch_channels: Default::default(),
             #[cfg(any(feature = "twitch", feature = "full"))]
-            twitch_token: Default::default(),
+            twitch_client_id: Default::default(),
+            #[cfg(any(feature = "twitch", feature = "full"))]
+            twitch_client_secret: Default::default(),
             #[cfg(any(feature = "twitch", feature = "full"))]
             twitch_bot_name: Default::default(),
         }
@@ -131,9 +136,20 @@ impl Config {
             },
         };
         #[cfg(any(feature = "twitch", feature = "full"))]
-        let twitch_token: String = match config_toml.twitch {
-            Some(tt) => tt.token.unwrap_or_else(|| {
-                error!("Missing field `token` in table [twitch]");
+        let twitch_client_id: String = match config_toml.twitch.clone() {
+            Some(tci) => tci.client_id.unwrap_or_else(|| {
+                error!("Missing field `client_id` in table [twitch]");
+                "twitch".to_string()
+            }),
+            None => {
+                error!("Missing table `[twitch]`.");
+                "twitch".to_string()
+            },
+        };
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        let twitch_client_secret: String = match config_toml.twitch {
+            Some(tcs) => tcs.client_secret.unwrap_or_else(|| {
+                error!("Missing field `client_secret` in table [twitch]");
                 "twitch".to_string()
             }),
             None => {
@@ -149,7 +165,9 @@ impl Config {
             #[cfg(any(feature = "twitch", feature = "full"))]
             twitch_channels,
             #[cfg(any(feature = "twitch", feature = "full"))]
-            twitch_token,
+            twitch_client_id,
+            #[cfg(any(feature = "twitch", feature = "full"))]
+            twitch_client_secret,
             #[cfg(any(feature = "twitch", feature = "full"))]
             twitch_bot_name,
         }
@@ -186,43 +204,88 @@ mod test {
     fn derives_config_toml_twitch() {
         let all_some = ConfigTomlTwitch {
             channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
-            token: Some("".to_string()),
+            client_id: Some("".to_string()),
+            client_secret: Some("".to_string()),
             bot_name: Some("".to_string()),
         };
         let _channels_some = ConfigTomlTwitch {
             channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
-            token: None,
+            client_id: None,
+            client_secret: None,
             bot_name: None,
         };
-        let _token_some =
-            ConfigTomlTwitch { channels: None, token: Some("".to_string()), bot_name: None };
-        let _bot_name_some =
-            ConfigTomlTwitch { channels: None, token: None, bot_name: Some("".to_string()) };
+        let _client_id_some = ConfigTomlTwitch {
+            channels: None,
+            client_id: Some("".to_string()),
+            client_secret: None,
+            bot_name: None,
+        };
+        let _client_secret_some = ConfigTomlTwitch {
+            channels: None,
+            client_id: None,
+            client_secret: Some("".to_string()),
+            bot_name: None,
+        };
+        let _bot_name_some = ConfigTomlTwitch {
+            channels: None,
+            client_id: None,
+            client_secret: None,
+            bot_name: Some("".to_string()),
+        };
         let _first_pair_some = ConfigTomlTwitch {
             channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
-            token: Some("".to_string()),
+            client_id: Some("".to_string()),
+            client_secret: None,
             bot_name: None,
         };
         let _second_pair_some = ConfigTomlTwitch {
             channels: None,
-            token: Some("".to_string()),
+            client_id: Some("".to_string()),
+            client_secret: Some("".to_string()),
+            bot_name: None,
+        };
+        let _one_three_some = ConfigTomlTwitch {
+            channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
+            client_id: None,
+            client_secret: Some("".to_string()),
+            bot_name: None,
+        };
+        let _two_four_some = ConfigTomlTwitch {
+            channels: None,
+            client_id: Some("".to_string()),
+            client_secret: None,
             bot_name: Some("".to_string()),
         };
         let _outer_some = ConfigTomlTwitch {
             channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
-            token: None,
+            client_id: None,
+            client_secret: None,
             bot_name: Some("".to_string()),
         };
-        let _all_none = ConfigTomlTwitch { channels: None, token: None, bot_name: None };
-        let _first_pair_none =
-            ConfigTomlTwitch { channels: None, token: None, bot_name: Some("".to_string()) };
-        let _second_pair_none = ConfigTomlTwitch {
-            channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
-            token: None,
+        let _all_none = ConfigTomlTwitch {
+            channels: None,
+            client_id: None,
+            client_secret: None,
             bot_name: None,
         };
-        let _outer_none =
-            ConfigTomlTwitch { channels: None, token: Some("".to_string()), bot_name: None };
+        let _first_pair_none = ConfigTomlTwitch {
+            channels: None,
+            client_id: None,
+            client_secret: Some("".to_string()),
+            bot_name: Some("".to_string()),
+        };
+        let _second_pair_none = ConfigTomlTwitch {
+            channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
+            client_id: None,
+            client_secret: None,
+            bot_name: Some("".to_string()),
+        };
+        let _outer_none = ConfigTomlTwitch {
+            channels: None,
+            client_id: Some("".to_string()),
+            client_secret: Some("".to_string()),
+            bot_name: None,
+        };
         let all_some_string = to_string(&all_some).unwrap(); // derive(Serialize)
         let _: ConfigTomlTwitch = from_str(&all_some_string).unwrap(); // derive(Deserialize)
         let _ = all_some.clone(); // derive(Clone)
@@ -240,7 +303,8 @@ mod test {
             #[cfg(any(feature = "twitch", feature = "full"))]
             twitch: Some(ConfigTomlTwitch {
                 channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
-                token: Some("".to_string()),
+                client_id: Some("".to_string()),
+                client_secret: Some("".to_string()),
                 bot_name: Some("".to_string()),
             }),
         };
@@ -259,12 +323,13 @@ mod test {
             #[cfg(any(feature = "twitch", feature = "full"))]
             twitch: Some(ConfigTomlTwitch {
                 channels: Some(vec!["Twitch".to_string(), "TwitchRivals".to_string()]),
-                token: Some("".to_string()),
+                client_id: Some("".to_string()),
+                client_secret: Some("".to_string()),
                 bot_name: Some("".to_string()),
             }),
         };
         let all_some_string = to_string(&all_some).unwrap(); // derive(Serialize)
-        let _: ConfigToml = from_str(&all_some_string).unwrap(); // derive(Deserialize)
+        let _: ConfigTomlTwitch = from_str(&all_some_string).unwrap(); // derive(Deserialize)
         let _ = format!("{:?}", all_some); // derive(Debug)
     }
 

--- a/ccg_bot_bin/src/discord/commands/id.rs
+++ b/ccg_bot_bin/src/discord/commands/id.rs
@@ -25,7 +25,9 @@ pub fn run(options: &CommandInteraction, cache: Arc<Cache>) -> CreateEmbed {
     let option = options.resolved.as_ref().expect("Expected user object");
 
     let res: CreateEmbed;
-    let CommandInteractionResolved::User(user, member) = option else { panic!("unexpected type in resolved")};
+    let CommandInteractionResolved::User(user, member) = option else {
+        panic!("unexpected type in resolved")
+    };
     let mut mem: PartialMember;
     if member.is_some() {
         mem = member.clone().unwrap();

--- a/ccg_bot_bin/src/main.rs
+++ b/ccg_bot_bin/src/main.rs
@@ -118,6 +118,11 @@ impl StdError for Error {
     }
 }
 
+#[cfg(not(any(feature = "discord", feature = "twitch", feature = "full")))]
+fn main() {
+    build_error!("Please rebuild with --feature [discord | twitch | full ] ");
+}
+
 #[tokio::main]
 async fn main() -> StdResult<(), Box<dyn StdError + Send + Sync>> {
     let mut log_var = String::from("");
@@ -131,25 +136,33 @@ async fn main() -> StdResult<(), Box<dyn StdError + Send + Sync>> {
     // In this case, a good default is setting the environment variable
     // `RUST_LOG` to `debug`, but for production, use the variable defined below.
     if !log_var.is_empty() {
-        env::set_var("RUST_LOG", format!("warn,ccg_bot={},meio=error", log_var));
+        env::set_var(
+            "RUST_LOG",
+            format!(
+                "warn,ccg_bot={},meio=error,twitch_irc={},reqwest={}",
+                &log_var, &log_var, log_var
+            ),
+        );
     } else {
-        env::set_var("RUST_LOG", "warn,CCG_Bot=warn,meio=error");
+        env::set_var("RUST_LOG", "warn,CCG_Bot=warn,meio=error,twitch_irc=warn");
     }
     tracing_subscriber::fmt::init();
     #[cfg(any(feature = "discord", feature = "twitch", feature = "full"))]
     let config: Config = Config::new();
     #[cfg(any(feature = "full", all(feature = "twitch", feature = "discord")))]
-    let discord_handle = tokio::spawn(discord::new(config.clone()));
+    let discord_handle = discord::new(config.clone());
     #[cfg(any(feature = "full", all(feature = "twitch", feature = "discord")))]
-    let twitch_handle = tokio::spawn(twitch::new(config.clone()));
-    #[cfg(any(feature = "full", feature = "discord"))]
-    let d = tokio::spawn(discord::new(config.clone()));
-    #[cfg(any(feature = "full", feature = "discord"))]
-    drop(d);
-    #[cfg(any(feature = "full", feature = "twitch"))]
-    let t = tokio::spawn(twitch::new(config.clone()));
-    #[cfg(any(feature = "full", feature = "twitch"))]
-    drop(t);
+    let twitch_handle = twitch::new(config.clone());
+    #[cfg(all(feature = "discord", not(any(feature = "full", feature = "twitch"))))]
+    match discord::new(config.clone()).await {
+        Ok(_) => (),
+        Err(e) => eprintln!("{:?}", e),
+    };
+    #[cfg(all(feature = "twitch", not(any(feature = "full", feature = "discord"))))]
+    match twitch::new(config.clone()).await {
+        Ok(_) => (),
+        Err(e) => eprintln!("{:?}", e),
+    };
     #[cfg(any(feature = "full", all(feature = "twitch", feature = "discord")))]
     let (_first, _second) = tokio::join!(discord_handle, twitch_handle);
     Ok(())
@@ -268,7 +281,5 @@ mod main_tests {
         let _ = Error::Json(je).source();
         #[cfg(any(feature = "discord", feature = "full"))]
         let _ = Error::Discord(DiscordError::VarErr(env::VarError::NotPresent)).source();
-        #[cfg(any(feature = "twitch", feature = "full"))]
-        let _ = Error::Twitch(TwitchError::VarErr(env::VarError::NotPresent)).source();
     }
 }

--- a/ccg_bot_bin/src/main.rs
+++ b/ccg_bot_bin/src/main.rs
@@ -118,9 +118,9 @@ impl StdError for Error {
     }
 }
 
-#[cfg(not(any(feature = "discord", feature = "twitch", feature = "full")))]
+#[cfg(not(any(feature = "discord", feature = "twitch", feature = "full", test)))]
 fn main() {
-    build_error!("Please rebuild with --feature [discord | twitch | full ] ");
+    std::compile_error!("Please rebuild with --feature [discord | twitch | full ] ");
 }
 
 #[tokio::main]

--- a/ccg_bot_bin/src/tests/discord.rs
+++ b/ccg_bot_bin/src/tests/discord.rs
@@ -45,7 +45,9 @@ fn it_works() {
         #[cfg(any(feature = "twitch", feature = "full"))]
         twitch_channels: vec!["".to_string()],
         #[cfg(any(feature = "twitch", feature = "full"))]
-        twitch_token: "".to_string(),
+        twitch_client_id: "".to_string(),
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_client_secret: "".to_string(),
     }));
     let disc_bool: bool = dc.is_ok();
     assert!(disc_bool);

--- a/ccg_bot_bin/src/tests/twitch.rs
+++ b/ccg_bot_bin/src/tests/twitch.rs
@@ -12,7 +12,9 @@ fn it_works() {
         #[cfg(any(feature = "twitch", feature = "full"))]
         twitch_channels: vec!["".to_string()],
         #[cfg(any(feature = "twitch", feature = "full"))]
-        twitch_token: "".to_string(),
+        twitch_client_id: "".to_string(),
+        #[cfg(any(feature = "twitch", feature = "full"))]
+        twitch_client_secret: "".to_string(),
     }));
     let twitch_bool: bool = twitch.is_ok();
     assert!(twitch_bool);

--- a/ccg_bot_bin/src/twitch/mod.rs
+++ b/ccg_bot_bin/src/twitch/mod.rs
@@ -8,10 +8,10 @@ use std::error;
 use std::fmt;
 
 //twitch_irc
-use twitch_irc::login::StaticLoginCredentials;
+use twitch_irc::login::RefreshingLoginCredentials;
 #[cfg(not(test))]
-use twitch_irc::message::{IRCMessage, PrivmsgMessage, ServerMessage};
-use twitch_irc::{ClientConfig, SecureTCPTransport, TwitchIRCClient};
+use twitch_irc::message::{IRCMessage, JoinMessage, PrivmsgMessage, ServerMessage};
+use twitch_irc::{SecureTCPTransport, TwitchIRCClient};
 
 //module(s)
 #[doc(hidden)]
@@ -25,31 +25,58 @@ pub struct Handler(pub Config);
 #[derive(Debug)]
 #[doc(hidden)]
 pub enum TwitchErr {
+    FailedToParse { key: String, value: String, error: Option<String> },
+    Other(String),
     VarErr(std::env::VarError),
 }
 
 #[doc(hidden)]
 impl fmt::Display for TwitchErr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
+            TwitchErr::FailedToParse { key, value, error } => {
+                let mut s = format!("Failed to parse {} as {}", value, key);
+                if let Some(e) = error {
+                    s.push_str(&format!(": {}", e));
+                }
+                write!(f, "{}", s)
+            },
             TwitchErr::VarErr(ref err) => write!(f, "Var error: {err}"),
+            TwitchErr::Other(ref err) => write!(f, "Var error: {err}"),
         }
     }
 }
 
 #[doc(hidden)]
 impl error::Error for TwitchErr {
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            TwitchErr::VarErr(ref err) => Some(err),
-        }
-    }
+    // fn cause(&self) -> Option<&dyn error::Error> {
+    //     match *self {
+    //         TwitchErr::VarErr(ref err) => Some(err),
+    //     }
+    // }
 }
 
 #[doc(hidden)]
 impl From<std::env::VarError> for TwitchErr {
     fn from(err: std::env::VarError) -> TwitchErr {
         TwitchErr::VarErr(err)
+    }
+}
+
+fn get_stacktrace(e: &dyn std::error::Error) -> String {
+    let mut s = vec![];
+    let mut source = Some(e);
+    while let Some(e) = source {
+        s.push(e.to_string());
+        source = e.source();
+    }
+    s.join("\n")
+}
+
+#[doc(hidden)]
+impl From<&dyn std::error::Error> for TwitchErr {
+    fn from(err: &dyn std::error::Error) -> Self {
+        TwitchErr::Other(get_stacktrace(err))
     }
 }
 
@@ -67,14 +94,24 @@ pub(crate) fn parse_message<L: AsRef<str> + std::fmt::Debug, M: AsRef<str> + std
 
 ///Creates a new chat listener for channels in your config.toml
 pub async fn new(config: Config) -> Result<Handler, std::env::VarError> {
-    let t = tokens::load_token(config.clone());
-    let conf = ClientConfig::new_simple(t);
+    // these credentials can be generated for your app at https://dev.twitch.tv/console/apps
+    // the bot's username will be fetched based on your access token
+    let cfg = config.clone();
+    let prefix = Some("TWITCH".to_string());
+
+    let storage = tokens::BotTokenStorage::new(&mut tokens::BotTokenStorage::default(), prefix);
+    let client_config = storage.client_config(cfg.clone());
+
     #[cfg(not(test))]
-    let (mut incoming_messages, client) =
-        TwitchIRCClient::<SecureTCPTransport, StaticLoginCredentials>::new(conf);
+    let (mut incoming_messages, client) = TwitchIRCClient::<
+        SecureTCPTransport,
+        RefreshingLoginCredentials<tokens::BotTokenStorage>,
+    >::new(client_config);
     #[cfg(test)]
-    let (_incoming_messages, _client) =
-        TwitchIRCClient::<SecureTCPTransport, StaticLoginCredentials>::new(conf);
+    let (_incoming_messages, _client) = TwitchIRCClient::<
+        SecureTCPTransport,
+        RefreshingLoginCredentials<tokens::BotTokenStorage>,
+    >::new(client_config);
     #[cfg(not(test))]
     let join_handle = tokio::spawn(async move {
         while let Some(message) = incoming_messages.recv().await {
@@ -92,9 +129,15 @@ pub async fn new(config: Config) -> Result<Handler, std::env::VarError> {
                 ServerMessage::GlobalUserState { .. } => {
                     parse_message("trace", format!("{:?}", message));
                 },
-                ServerMessage::Join { .. } => {
-                    parse_message("info", format!("{:?}", message));
-                }, //FIXME: parse join messages like we do privmsg's
+                ServerMessage::Join { .. } => println!(
+                    "[twitch / #{}] {} joined",
+                    JoinMessage::try_from(Into::<IRCMessage>::into(message.clone()))
+                        .unwrap()
+                        .channel_login,
+                    JoinMessage::try_from(Into::<IRCMessage>::into(message.clone()))
+                        .unwrap()
+                        .user_login,
+                ),
                 ServerMessage::Notice { .. } => {
                     parse_message("trace", format!("{:?}", message));
                 },
@@ -133,14 +176,14 @@ pub async fn new(config: Config) -> Result<Handler, std::env::VarError> {
                     parse_message("trace", format!("{:?}", message));
                 },
                 ServerMessage::Whisper { .. } => {
-                    parse_message("trace", format!("{:?}", message));
+                    parse_message("debug", format!("{:?}", message));
                 },
                 _ => eprintln!("received unexpected message variant {:?}", message),
             }
         }
     });
     #[cfg(not(test))]
-    for channel in &config.twitch_channels {
+    for channel in &cfg.twitch_channels {
         client.join(channel.to_owned().to_lowercase()).unwrap();
     }
     #[cfg(not(test))]
@@ -184,7 +227,9 @@ mod tests {
             #[cfg(any(feature = "twitch", feature = "full"))]
             twitch_channels: vec![],
             #[cfg(any(feature = "twitch", feature = "full"))]
-            twitch_token: "".to_string(),
+            twitch_client_id: "".to_string(),
+            #[cfg(any(feature = "twitch", feature = "full"))]
+            twitch_client_secret: "".to_string(),
         });
         let _ = format!("{:?}", handle);
     }

--- a/ccg_bot_bin/src/twitch/tokens.rs
+++ b/ccg_bot_bin/src/twitch/tokens.rs
@@ -1,9 +1,181 @@
-use crate::config::Config;
-use twitch_irc::login::StaticLoginCredentials;
+use async_trait::async_trait;
+use chrono::serde::ts_seconds::deserialize as from_ts_seconds;
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
-#[doc(hidden)]
-pub(crate) fn load_token(config: Config) -> StaticLoginCredentials {
-    let login_name = config.twitch_bot_name;
-    let token = config.twitch_token;
-    StaticLoginCredentials::new(login_name, Some(token))
+//twitc_irc
+use twitch_irc::{
+    login::{GetAccessTokenResponse, RefreshingLoginCredentials, TokenStorage, UserAccessToken},
+    ClientConfig,
+};
+
+// crate
+use crate::config::Config;
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct BotTokenStorage {
+    prefix: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct Token {
+    access_token: String,
+    refresh_token: String,
+    #[serde(deserialize_with = "from_ts_seconds")]
+    created_at: DateTime<Utc>,
+    #[serde(deserialize_with = "from_ts_seconds")]
+    expires_at: DateTime<Utc>,
+}
+
+impl BotTokenStorage {
+    pub fn new(&mut self, prefix: Option<String>) -> BotTokenStorage {
+        if let Some(prefix) = &prefix {
+            if prefix.contains('_') {
+                panic!("Prefix cannot contain underscores");
+            }
+        }
+        Self { prefix }
+    }
+
+    pub fn client_config(
+        self,
+        config: Config,
+    ) -> ClientConfig<RefreshingLoginCredentials<BotTokenStorage>> {
+        let username = Some(config.twitch_bot_name);
+        let client_id = config.twitch_client_id;
+        let client_secret = config.twitch_client_secret;
+        let env = self;
+        let rlc =
+            RefreshingLoginCredentials::init_with_username(username, client_id, client_secret, env);
+        ClientConfig::new_simple(rlc)
+    }
+
+    pub fn get_env<T>(&self, key: &str) -> Result<T, super::TwitchErr>
+    where
+        T: std::str::FromStr,
+        <T as std::str::FromStr>::Err: std::fmt::Debug,
+    {
+        self.get_env_opt(key)?
+            .ok_or_else(|| super::TwitchErr::VarErr(std::env::VarError::NotPresent))
+    }
+
+    pub fn get_env_opt<T>(&self, key: &str) -> Result<Option<T>, super::TwitchErr>
+    where
+        T: std::str::FromStr,
+        <T as std::str::FromStr>::Err: std::fmt::Debug,
+    {
+        let key = if let Some(prefix) = &self.prefix {
+            format!("{}_{}", prefix, key)
+        } else {
+            key.to_string()
+        };
+
+        let value = std::env::var(&key).map_err(|_e| std::env::VarError::NotPresent)?;
+        debug!("Found env: {}={}", key, value);
+
+        let value = value.parse::<T>().map_err(|e| super::TwitchErr::FailedToParse {
+            key: key.to_string(),
+            value: value.to_string(),
+            error: Some(format!("{:?}", e)),
+        })?;
+
+        Ok(Some(value))
+    }
+
+    pub fn set_env<T>(&self, key: &str, value: T) -> Result<(), super::TwitchErr>
+    where
+        T: ToString,
+    {
+        let key = self.format_key(key);
+        let value = value.to_string();
+        std::env::set_var(&key, &value);
+
+        Ok(())
+    }
+
+    fn format_key(&self, key: &str) -> String {
+        let key = key.to_uppercase();
+        if let Some(prefix) = &self.prefix {
+            format!("{}_{}", prefix, key)
+        } else {
+            key
+        }
+    }
+}
+
+impl From<UserAccessToken> for Token {
+    fn from(value: UserAccessToken) -> Self {
+        Self {
+            access_token: value.access_token,
+            refresh_token: value.refresh_token,
+            created_at: value.created_at,
+            expires_at: value.expires_at.unwrap_or_default(),
+        }
+    }
+}
+
+impl From<GetAccessTokenResponse> for Token {
+    fn from(value: GetAccessTokenResponse) -> Self {
+        let now = Utc::now();
+        Self {
+            access_token: value.access_token,
+            refresh_token: value.refresh_token,
+            created_at: now,
+            expires_at: value
+                .expires_in
+                .map(|d| now + chrono::Duration::from_std(Duration::from_secs(d)).unwrap())
+                .unwrap(),
+        }
+    }
+}
+
+#[async_trait]
+impl TokenStorage for BotTokenStorage {
+    type LoadError = std::io::Error; // or some other error
+    type UpdateError = std::io::Error;
+
+    async fn load_token(&mut self) -> Result<UserAccessToken, Self::LoadError> {
+        let at = match self.get_env("ACCESS_TOKEN") {
+            Ok(v) => v,
+            Err(_) => "".to_string(),
+        };
+        let rt = match self.get_env("REFRESH_TOKEN") {
+            Ok(v) => v,
+            Err(_) => "".to_string(),
+        };
+        let ca: DateTime<Utc> = match self.get_env("TOKEN_CREATED_AT") {
+            Ok(v) => v,
+            Err(_) => Utc::now(),
+        };
+        let ea: DateTime<Utc> = match self.get_env("TOKEN_EXPIRES_AT") {
+            Ok(v) => v,
+            Err(_) => Utc::now() + chrono::Duration::seconds(7500_i64),
+        };
+        let token = Token { access_token: at, refresh_token: rt, created_at: ca, expires_at: ea };
+        debug!("[load_token] token = {token:?}");
+        let uat = UserAccessToken {
+            access_token: token.access_token,
+            refresh_token: token.refresh_token,
+            created_at: token.created_at,
+            expires_at: Some(token.expires_at),
+        };
+        trace!("uat {:?}", &uat);
+        Ok(uat)
+    }
+
+    async fn update_token(&mut self, token: &UserAccessToken) -> Result<(), Self::UpdateError> {
+        let s = self.clone();
+        debug!("[update_token] self = {s:?}");
+        debug!("[update_token] token = {token:?}");
+        self.set_env("ACCESS_TOKEN", &token.access_token).unwrap();
+        let self_clone = self.clone();
+        debug!("[update_token] self_clone = {self_clone:?}");
+        self.set_env("REFRESH_TOKEN", &token.refresh_token).unwrap();
+        self.set_env("TOKEN_CREATED_AT", token.created_at).unwrap();
+        self.set_env("TOKEN_EXPIRES_AT", token.expires_at.unwrap_or_default()).unwrap();
+        let new_self = self.clone();
+        debug!("[update_token] new_self = {new_self:?}");
+        Ok(())
+    }
 }


### PR DESCRIPTION
Set up the ground work for being able to use a RefreshingTokenCredential instead of a StaticLoginCredential while maintaining the ability to allow handling of static credentials from both the [config.toml](ccg_bot_bin/config.toml.example) and environment variables.

Update `cargo.lock` to close #20 by incorporating it into this PR.